### PR TITLE
Changed SAVE_IP env var to be case-insensitive.

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -21,7 +21,7 @@ else
 fi
 
 # load IP if saved
-if [[ "${SAVE_IP}" == "True" ]]; then
+if [[ "${SAVE_IP^^}" == "TRUE" ]]; then
     if [[ -f "$savedIPFile" ]]; then
         old_ip=$( cat ${savedIPFile} | tr -d " \t\n\r" )
     else


### PR DESCRIPTION
When I first added the SAVE_IP env var to my container it wasn't working because it is case sensitive. I think it would be more intuitive if it wasn't. I've made a small tweak to the bash script to make the input case-insensitive.

Thanks for making this simple and helpful app.